### PR TITLE
refactor: use a centralized data directory 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 
 # Create directories for persistent data (media, static, and database)
 RUN mkdir -p /app/media /app/static
-VOLUME ["/app/media", "/app/static", "/app/db.sqlite3"]
+VOLUME ["/app/data"]
 
 # Collect static files for Django admin and other static assets
 RUN uv run python manage.py collectstatic --noinput

--- a/dmr/settings.py
+++ b/dmr/settings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+DATA_DIR = BASE_DIR / "data"
 
 
 # Quick-start development settings - unsuitable for production
@@ -86,7 +87,7 @@ ASGI_APPLICATION = "dmr.asgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "NAME": DATA_DIR / "db.sqlite3",
     }
 }
 
@@ -126,11 +127,11 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
 STATIC_URL = "static/"
-STATIC_ROOT = BASE_DIR / "static"
+STATIC_ROOT = DATA_DIR / "static"
 
 # Media files (user uploads)
 MEDIA_URL = "/media/"
-MEDIA_ROOT = BASE_DIR / "media"
+MEDIA_ROOT = DATA_DIR / "media"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field


### PR DESCRIPTION
This pull request updates how persistent data is managed by consolidating media, static files, and the database into a single `data` directory. This change improves organization and simplifies volume management for Docker deployments.

**Persistent data directory migration:**

* Changed the Docker volume declaration to use a unified `/app/data` directory instead of separate volumes for media, static, and database files in `Dockerfile`.
* Introduced a new `DATA_DIR` variable in `dmr/settings.py` to represent the `data` directory.

**Django settings updates:**

* Updated the SQLite database path to use `DATA_DIR / "db.sqlite3"` instead of `BASE_DIR / "db.sqlite3"` in `dmr/settings.py`.
* Changed `STATIC_ROOT` and `MEDIA_ROOT` to use `DATA_DIR` for storing static and media files, respectively, in `dmr/settings.py`.