### PR TITLE
fix: Docker cannot init db file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,15 @@ ENV PATH="/app/.venv/bin:${PATH}"
 # Copy the rest of the application code
 COPY . .
 
-# Create directories for persistent data (media, static, and database)
-RUN mkdir -p /app/media /app/static
+# Create directories for persistent data (media, static)
+RUN mkdir -p /app/data/media /app/data/static
 VOLUME ["/app/data"]
 
 # Collect static files for Django admin and other static assets
 RUN uv run python manage.py collectstatic --noinput
+
+# Migrate the database
+RUN uv run python manage.py migrate --noinput
 
 # Set environment variables
 ENV DJANGO_SETTINGS_MODULE=dmr.settings


### PR DESCRIPTION
This pull request updates the Docker setup for the application by reorganizing persistent data directories and improving the deployment process. The most notable changes are in how static and media files are handled and the addition of a database migration step during image build.

**Dockerfile improvements:**

* Changed static and media directories to be under `/app/data` instead of `/app`, ensuring better separation of persistent data.
* Added a database migration step (`python manage.py migrate --noinput`) to the build process, helping ensure the database schema is up-to-date when the image is built.