### PR TITLE
refactor: remove unnecessary static file collection and migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,6 @@ COPY . .
 RUN mkdir -p /app/data/media /app/data/static
 VOLUME ["/app/data"]
 
-# Collect static files for Django admin and other static assets
-RUN uv run python manage.py collectstatic --noinput
-
-# Migrate the database
-RUN uv run python manage.py migrate --noinput
-
 # Set environment variables
 ENV DJANGO_SETTINGS_MODULE=dmr.settings
 ENV DJANGO_CONFIGURATION=Production


### PR DESCRIPTION
This pull request removes the steps for collecting static files and migrating the database from the Docker build process. These operations are no longer performed during image creation, which simplifies the Dockerfile and shifts responsibility for these tasks to runtime or deployment scripts.

Deployment process changes:

* Removed commands that collect Django static files (`collectstatic`) and migrate the database (`migrate`) from the Docker build process in `Dockerfile`.