### PR TITLE
Feature/refactor lab request

### DIFF
--- a/dmr/settings.py
+++ b/dmr/settings.py
@@ -181,6 +181,11 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
     ],
+    "DEFAULT_PARSER_CLASSES": [
+        "rest_framework.parsers.JSONParser",
+        "rest_framework.parsers.MultiPartParser",
+        "rest_framework.parsers.FormParser",
+    ],
 }
 
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
This pull request enhances the file upload and management functionality for patient records, focusing on improved API documentation, validation, and usability. Key changes include more robust validation for file uploads, automatic naming, expanded OpenAPI documentation for endpoints, and clearer separation of permissions and file categories.

**API Improvements and Documentation:**

* Added detailed OpenAPI documentation and examples to both legacy and new file upload endpoints, including descriptions, summaries, and request/response schemas for all CRUD actions in `FileViewSet` and `PatientViewSet`. This provides clear guidance for API consumers and improves discoverability of features. [[1]](diffhunk://#diff-2958b79a5bf0960ac4a15e615afeed3ff18b73c0142384955b0d6acd5af23b69R21-R67) [[2]](diffhunk://#diff-2958b79a5bf0960ac4a15e615afeed3ff18b73c0142384955b0d6acd5af23b69R81-R203)

**Validation and Usability Enhancements:**

* Implemented validation in `FileSerializer` to ensure that the `requires_pagination` flag can only be set for PDF files, preventing incorrect usage and providing clear error messages.
* Automatically sets the `display_name` of a file to the uploaded filename during creation, improving consistency and reducing manual effort.

**Permissions and File Categories:**

* Clarified and documented permission logic for file and patient endpoints, separating CRUD access for instructors/admins from view-only access for students, and distinguishing between management and access permissions.
* Provided comprehensive descriptions of file categories in the `FileViewSet` docstring, making it easier for users to understand and select appropriate categories.

**Parser and Serializer Configuration:**

* Configured default parser classes in `dmr/settings.py` to support JSON, multipart, and form data, ensuring compatibility with various file upload formats.
* Enhanced field-level documentation in `FileSerializer` for better API introspection and developer experience.